### PR TITLE
set the version of ruby gems used by the minitest workflow to latests

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -17,6 +17,7 @@ jobs:
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true
           ruby-version: '2.6'
+          rubygems: 'latest'
       - name: Run tests
         run: |
           rake test


### PR DESCRIPTION
This resolves the following deprecating warning:
```
Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
```